### PR TITLE
Include previously granted scopes in token.Scope

### DIFF
--- a/Src/Support/Google.Apis.Auth/OAuth2/AuthorizationCodeInstalledApp.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/AuthorizationCodeInstalledApp.cs
@@ -14,16 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+using Google.Apis.Auth.OAuth2.Flows;
+using Google.Apis.Auth.OAuth2.Responses;
+using Google.Apis.Auth.OAuth2.Requests;
+using Google.Apis.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-
-using Google.Apis.Auth.OAuth2.Flows;
-using Google.Apis.Auth.OAuth2.Responses;
-using Google.Apis.Auth.OAuth2.Requests;
-using Google.Apis.Logging;
 
 namespace Google.Apis.Auth.OAuth2
 {

--- a/Src/Support/Google.Apis.Auth/OAuth2/AuthorizationCodeInstalledApp.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/AuthorizationCodeInstalledApp.cs
@@ -14,6 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -35,31 +38,22 @@ namespace Google.Apis.Auth.OAuth2
     {
         private static readonly ILogger Logger = ApplicationContext.Logger.ForType<AuthorizationCodeInstalledApp>();
 
-        private readonly IAuthorizationCodeFlow flow;
-        private readonly ICodeReceiver codeReceiver;
-
         /// <summary>
         /// Constructs a new authorization code installed application with the given flow and code receiver.
         /// </summary>
         public AuthorizationCodeInstalledApp(IAuthorizationCodeFlow flow, ICodeReceiver codeReceiver)
         {
-            this.flow = flow;
-            this.codeReceiver = codeReceiver;
+            Flow = flow;
+            CodeReceiver = codeReceiver;
         }
 
         #region IAuthorizationCodeInstalledApp Members
 
         /// <summary>Gets the authorization code flow.</summary>
-        public IAuthorizationCodeFlow Flow
-        {
-            get { return flow; }
-        }
+        public IAuthorizationCodeFlow Flow { get; private set; }
 
         /// <summary>Gets the code receiver which is responsible for receiving the authorization code.</summary>
-        public ICodeReceiver CodeReceiver
-        {
-            get { return codeReceiver; }
-        }
+        public ICodeReceiver CodeReceiver { get; private set; }
 
         /// <inheritdoc/>
         public async Task<UserCredential> AuthorizeAsync(string userId, CancellationToken taskCancellationToken)
@@ -87,12 +81,20 @@ namespace Google.Apis.Auth.OAuth2
 
                 Logger.Debug("Received \"{0}\" code", response.Code);
 
+                // If include granted scopes is specified, then pass the current scopes
+                // to ExchangeCodeForTokenAsync.
+                string[] grantedScopes = null;
+                if (Flow.IncludeGrantedScopes.HasValue && Flow.IncludeGrantedScopes.Value)
+                {
+                    grantedScopes = token.Scope?.Split(new[] {' '}, StringSplitOptions.RemoveEmptyEntries);
+                }
+
                 // Get the token based on the code.
-                token = await Flow.ExchangeCodeForTokenAsync(userId, response.Code, redirectUri,
+                token = await Flow.ExchangeCodeForTokenAsync(userId, response.Code, grantedScopes, redirectUri,
                     taskCancellationToken).ConfigureAwait(false);
             }
 
-            return new UserCredential(flow, userId, token);
+            return new UserCredential(Flow, userId, token);
         }
 
         /// <summary>
@@ -102,10 +104,30 @@ namespace Google.Apis.Auth.OAuth2
         public bool ShouldRequestAuthorizationCode(TokenResponse token)
         {
             // TODO: This code should be shared between this class and AuthorizationCodeWebApp.
-            // If the flow includes a parameter that requires a new token, if the stored token is null or it doesn't
-            // have a refresh token and the access token is expired we need to retrieve a new authorization code.
-            return Flow.ShouldForceTokenRetrieval() || token == null || (token.RefreshToken == null 
-                && token.IsExpired(flow.Clock));
+
+            // If the token or access-token is null, need to retrieve a new authorization code.
+            if (token?.AccessToken == null)
+            {
+                return true;
+            }
+
+            // Is the token is expired, and we don't have a refresh token, need to retrieve a new auth code.
+            if (token.IsExpired(Flow.Clock) && token.RefreshToken == null)
+            {
+                return true;
+            }
+
+            // If the current token.Scope does not include the requested scopes, then
+            // an authorization code is required.
+            var tokenScopes = new HashSet<string>(token.Scope.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries));
+            if (Flow.Scopes.All(x => tokenScopes.Contains(x)))
+            {
+                // All requested scopes have already been authorized.
+                return false;
+            }
+
+            // GoogleAuthorizationCodeFlow always returns true if IncludeGrantedScopes is true.
+            return Flow.ShouldForceTokenRetrieval();
         }
 
         #endregion

--- a/Src/Support/Google.Apis.Auth/OAuth2/Flows/AuthorizationCodeFlow.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/Flows/AuthorizationCodeFlow.cs
@@ -232,7 +232,7 @@ namespace Google.Apis.Auth.OAuth2.Flows
 
         /// <inheritdoc/>
         public async Task<TokenResponse> ExchangeCodeForTokenAsync(string userId, string code, 
-            IEnumerable<string> includedGrantedScopes, string redirectUri, CancellationToken taskCancellationToken)
+            IEnumerable<string> grantedScopes, string redirectUri, CancellationToken taskCancellationToken)
         {
             var authorizationCodeTokenReq = new AuthorizationCodeTokenRequest
             {
@@ -250,7 +250,7 @@ namespace Google.Apis.Auth.OAuth2.Flows
             if (string.IsNullOrEmpty(token.Scope))
             {
                 // Initialize tokenScopes with the included granted scopes (if any)
-                var tokenScopes = new HashSet<string>(includedGrantedScopes ?? new HashSet<string>());
+                var tokenScopes = new HashSet<string>(grantedScopes ?? new HashSet<string>());
                 // Add requested scopes
                 foreach (var scope in Scopes)
                 {

--- a/Src/Support/Google.Apis.Auth/OAuth2/Flows/AuthorizationCodeFlow.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/Flows/AuthorizationCodeFlow.cs
@@ -17,7 +17,6 @@ limitations under the License.
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -79,6 +78,9 @@ namespace Google.Apis.Auth.OAuth2.Flows
             /// </summary>
             public IEnumerable<string> Scopes { get; set; }
 
+            /// <summary>Gets or sets the include granted scopes indicator</summary>
+            public bool? IncludeGrantedScopes { get; set; }
+
             /// <summary>
             /// Gets or sets the factory for creating <see cref="System.Net.Http.HttpClient"/> instance.
             /// </summary>
@@ -117,42 +119,32 @@ namespace Google.Apis.Auth.OAuth2.Flows
 
         #endregion
 
-        #region Readonly fields
-
-        private readonly IAccessMethod accessMethod;
-        private readonly string tokenServerUrl;
-        private readonly string authorizationServerUrl;
-        private readonly ClientSecrets clientSecrets;
-        private readonly IDataStore dataStore;
-        private readonly IEnumerable<string> scopes;
-        private readonly ConfigurableHttpClient httpClient;
-        private readonly IClock clock;
-
-        #endregion
-
         /// <summary>Gets the token server URL.</summary>
-        public string TokenServerUrl { get { return tokenServerUrl; } }
+        public string TokenServerUrl { get; private set; }
 
         /// <summary>Gets the authorization code server URL.</summary>
-        public string AuthorizationServerUrl { get { return authorizationServerUrl; } }
+        public string AuthorizationServerUrl { get; private set; }
 
         /// <summary>Gets the client secrets which includes the client identifier and its secret.</summary>
-        public ClientSecrets ClientSecrets { get { return clientSecrets; } }
+        public ClientSecrets ClientSecrets { get; private set; }
 
         /// <summary>Gets the data store used to store the credentials.</summary>
-        public IDataStore DataStore { get { return dataStore; } }
+        public IDataStore DataStore { get; private set; }
+
+        /// <summary>Gets or sets the include granted scopes indicator.</summary>
+        public bool? IncludeGrantedScopes { get; private set; }
 
         /// <summary>Gets the scopes which indicate the API access your application is requesting.</summary>
-        public IEnumerable<string> Scopes { get { return scopes; } }
+        public IEnumerable<string> Scopes { get; private set; }
 
         /// <summary>Gets the HTTP client used to make authentication requests to the server.</summary>
-        public ConfigurableHttpClient HttpClient { get { return httpClient; } }
+        public ConfigurableHttpClient HttpClient { get; private set; }
 
         /// <summary>Constructs a new flow using the initializer's properties.</summary>
         public AuthorizationCodeFlow(Initializer initializer)
         {
-            clientSecrets = initializer.ClientSecrets;
-            if (clientSecrets == null)
+            ClientSecrets = initializer.ClientSecrets;
+            if (ClientSecrets == null)
             {
                 if (initializer.ClientSecretsStream == null)
                 {
@@ -161,7 +153,7 @@ namespace Google.Apis.Auth.OAuth2.Flows
 
                 using (initializer.ClientSecretsStream)
                 {
-                    clientSecrets = GoogleClientSecrets.Load(initializer.ClientSecretsStream).Secrets;
+                    ClientSecrets = GoogleClientSecrets.Load(initializer.ClientSecretsStream).Secrets;
                 }
             }
             else if (initializer.ClientSecretsStream != null)
@@ -170,18 +162,20 @@ namespace Google.Apis.Auth.OAuth2.Flows
                     "You CAN'T set both ClientSecrets AND ClientSecretStream on the initializer");
             }
 
-            accessMethod = initializer.AccessMethod.ThrowIfNull("Initializer.AccessMethod");
-            clock = initializer.Clock.ThrowIfNull("Initializer.Clock");
-            tokenServerUrl = initializer.TokenServerUrl.ThrowIfNullOrEmpty("Initializer.TokenServerUrl");
-            authorizationServerUrl = initializer.AuthorizationServerUrl.ThrowIfNullOrEmpty
+            AccessMethod = initializer.AccessMethod.ThrowIfNull("Initializer.AccessMethod");
+            Clock = initializer.Clock.ThrowIfNull("Initializer.Clock");
+            TokenServerUrl = initializer.TokenServerUrl.ThrowIfNullOrEmpty("Initializer.TokenServerUrl");
+            AuthorizationServerUrl = initializer.AuthorizationServerUrl.ThrowIfNullOrEmpty
                 ("Initializer.AuthorizationServerUrl");
 
-            dataStore = initializer.DataStore;
-            if (dataStore == null)
+            DataStore = initializer.DataStore;
+            if (DataStore == null)
             {
                 Logger.Warning("Datastore is null, as a result the user's credential will not be stored");
             }
-            scopes = initializer.Scopes;
+
+            Scopes = initializer.Scopes;
+            IncludeGrantedScopes = initializer.IncludeGrantedScopes;
 
             // Set the HTTP client.
             var httpArgs = new CreateHttpClientArgs();
@@ -193,16 +187,16 @@ namespace Google.Apis.Auth.OAuth2.Flows
                     new ExponentialBackOffInitializer(initializer.DefaultExponentialBackOffPolicy,
                         () => new BackOffHandler(new ExponentialBackOff())));
             }
-            httpClient = (initializer.HttpClientFactory ?? new HttpClientFactory()).CreateHttpClient(httpArgs);
+            HttpClient = (initializer.HttpClientFactory ?? new HttpClientFactory()).CreateHttpClient(httpArgs);
         }
 
         #region IAuthorizationCodeFlow overrides
 
         /// <inheritdoc/>
-        public IAccessMethod AccessMethod { get { return accessMethod; } }
+        public IAccessMethod AccessMethod { get; private set; }
 
         /// <inheritdoc/>
-        public IClock Clock { get { return clock; } }
+        public IClock Clock { get; private set; }
 
         /// <inheritdoc/>
         public async Task<TokenResponse> LoadTokenAsync(string userId, CancellationToken taskCancellationToken)
@@ -237,8 +231,8 @@ namespace Google.Apis.Auth.OAuth2.Flows
         }
 
         /// <inheritdoc/>
-        public async Task<TokenResponse> ExchangeCodeForTokenAsync(string userId, string code, string redirectUri,
-            CancellationToken taskCancellationToken)
+        public async Task<TokenResponse> ExchangeCodeForTokenAsync(string userId, string code, 
+            IEnumerable<string> includedGrantedScopes, string redirectUri, CancellationToken taskCancellationToken)
         {
             var authorizationCodeTokenReq = new AuthorizationCodeTokenRequest
             {
@@ -255,7 +249,18 @@ namespace Google.Apis.Auth.OAuth2.Flows
             // See AuthorizationCodeWebApp.ShouldRequestAuthorizationCode(TokenResponse token).
             if (string.IsNullOrEmpty(token.Scope))
             {
-                token.Scope = authorizationCodeTokenReq.Scope;
+                // Initialize tokenScopes with the included granted scopes (if any)
+                var tokenScopes = new HashSet<string>(includedGrantedScopes ?? new HashSet<string>());
+                // Add requested scopes
+                foreach (var scope in Scopes)
+                {
+                    if (!tokenScopes.Contains(scope))
+                    {
+                        tokenScopes.Add(scope);
+                    }
+                }
+
+                token.Scope = string.Join(" ", tokenScopes);
             }
 
             await StoreTokenAsync(userId, token, taskCancellationToken).ConfigureAwait(false);
@@ -302,7 +307,7 @@ namespace Google.Apis.Auth.OAuth2.Flows
             taskCancellationToken.ThrowIfCancellationRequested();
             if (DataStore != null)
             {
-                await DataStore.StoreAsync<TokenResponse>(userId, token).ConfigureAwait(false);
+                await DataStore.StoreAsync(userId, token).ConfigureAwait(false);
             }
         }
 
@@ -322,7 +327,7 @@ namespace Google.Apis.Auth.OAuth2.Flows
             try
             {
                 var tokenResponse = await request.ExecuteAsync
-                    (httpClient, TokenServerUrl, taskCancellationToken, Clock).ConfigureAwait(false);
+                    (HttpClient, TokenServerUrl, taskCancellationToken, Clock).ConfigureAwait(false);
                 return tokenResponse;
             }
             catch (TokenResponseException ex)

--- a/Src/Support/Google.Apis.Auth/OAuth2/Flows/GoogleAuthorizationCodeFlow.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/Flows/GoogleAuthorizationCodeFlow.cs
@@ -31,36 +31,22 @@ namespace Google.Apis.Auth.OAuth2.Flows
     /// </summary>
     public class GoogleAuthorizationCodeFlow : AuthorizationCodeFlow
     {
-        private readonly string revokeTokenUrl;
-
         /// <summary>Gets the token revocation URL.</summary>
-        public string RevokeTokenUrl { get { return revokeTokenUrl; } }
-
-        /// <summary>Gets or sets the include granted scopes indicator.
-        /// Do not use, use <see cref="IncludeGrantedScopes"/> instead.</summary>
-        public readonly bool? includeGrantedScopes;
-
-        /// <summary>Gets or sets the include granted scopes indicator.</summary>
-        public bool? IncludeGrantedScopes { get { return includeGrantedScopes; } }
+        public string RevokeTokenUrl { get; private set; }
 
         /// <summary>Gets or sets the login_hint.</summary>
-        public string LoginHint { get; set; }
-
-        private readonly IEnumerable<KeyValuePair<string, string>> userDefinedQueryParams;
+        public string LoginHint { get; private set; }
 
         /// <summary>Gets the user defined query parameters.</summary>
-        public IEnumerable<KeyValuePair<string, string>> UserDefinedQueryParams
-        { 
-            get { return userDefinedQueryParams; } 
-        }
+        public IEnumerable<KeyValuePair<string, string>> UserDefinedQueryParams { get; private set; }
 
         /// <summary>Constructs a new Google authorization code flow.</summary>
         public GoogleAuthorizationCodeFlow(Initializer initializer)
             : base(initializer)
         {
-            revokeTokenUrl = initializer.RevokeTokenUrl;
-            includeGrantedScopes = initializer.IncludeGrantedScopes;
-            userDefinedQueryParams = initializer.UserDefinedQueryParams;
+            LoginHint = initializer.LoginHint;
+            RevokeTokenUrl = initializer.RevokeTokenUrl;
+            UserDefinedQueryParams = initializer.UserDefinedQueryParams;
         }
 
         /// <inheritdoc/>
@@ -108,13 +94,14 @@ namespace Google.Apis.Auth.OAuth2.Flows
         /// <summary>An initializer class for Google authorization code flow. </summary>
         public new class Initializer : AuthorizationCodeFlow.Initializer
         {
-            /// <summary>Gets or sets the token revocation URL.</summary>
-            public string RevokeTokenUrl { get; set; }
-
             /// <summary>
-            /// Gets or sets the optional indicator for including granted scopes for incremental authorization.
+            /// Gets or sets the login_hint.
+            /// Set the parameter to an email address or sub identifier.
             /// </summary>
-            public bool? IncludeGrantedScopes { get; set; }
+            public string LoginHint { get; set; }
+
+            /// <summary>Gets or sets the token revocation URL.</summary>
+            public string RevokeTokenUrl { get; private set; }
 
             /// <summary>Gets or sets the optional user defined query parameters.</summary>
             public IEnumerable<KeyValuePair<string, string>> UserDefinedQueryParams { get; set; }

--- a/Src/Support/Google.Apis.Auth/OAuth2/Flows/IAuthorizationCodeFlow.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/Flows/IAuthorizationCodeFlow.cs
@@ -67,11 +67,11 @@ namespace Google.Apis.Auth.OAuth2.Flows
         /// <summary>Asynchronously exchanges code with a token.</summary>
         /// <param name="userId">User identifier.</param>
         /// <param name="code">Authorization code received from the authorization server.</param>
-        /// <param name="includedGrantedScopes">Previously granted scopes if include granted scopes specified.</param>
+        /// <param name="grantedScopes">Previously granted scopes if include granted scopes specified.</param>
         /// <param name="redirectUri">Redirect URI which is used in the token request.</param>
         /// <param name="taskCancellationToken">Cancellation token to cancel operation.</param>
         /// <returns>Token response which contains the access token.</returns>
-        Task<TokenResponse> ExchangeCodeForTokenAsync(string userId, string code, IEnumerable<string> includedGrantedScopes, 
+        Task<TokenResponse> ExchangeCodeForTokenAsync(string userId, string code, IEnumerable<string> grantedScopes, 
             string redirectUri, CancellationToken taskCancellationToken);
 
         /// <summary>Asynchronously refreshes an access token using a refresh token.</summary>

--- a/Src/Support/Google.Apis.Auth/OAuth2/Flows/IAuthorizationCodeFlow.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/Flows/IAuthorizationCodeFlow.cs
@@ -37,6 +37,9 @@ namespace Google.Apis.Auth.OAuth2.Flows
 
         /// <summary>Gets the data store used to store the credentials.</summary>
         IDataStore DataStore { get; }
+        
+        /// <summary>Gets the include granted scopes indicator.</summary>
+        bool? IncludeGrantedScopes { get; }
 
         /// <summary>Gets the scopes which indicate the API access your application is requesting.</summary>
         IEnumerable<string> Scopes { get; }
@@ -64,11 +67,12 @@ namespace Google.Apis.Auth.OAuth2.Flows
         /// <summary>Asynchronously exchanges code with a token.</summary>
         /// <param name="userId">User identifier.</param>
         /// <param name="code">Authorization code received from the authorization server.</param>
+        /// <param name="includedGrantedScopes">Previously granted scopes if include granted scopes specified.</param>
         /// <param name="redirectUri">Redirect URI which is used in the token request.</param>
         /// <param name="taskCancellationToken">Cancellation token to cancel operation.</param>
         /// <returns>Token response which contains the access token.</returns>
-        Task<TokenResponse> ExchangeCodeForTokenAsync(string userId, string code, string redirectUri,
-            CancellationToken taskCancellationToken);
+        Task<TokenResponse> ExchangeCodeForTokenAsync(string userId, string code, IEnumerable<string> includedGrantedScopes, 
+            string redirectUri, CancellationToken taskCancellationToken);
 
         /// <summary>Asynchronously refreshes an access token using a refresh token.</summary>
         /// <param name="userId">User identifier.</param>

--- a/Src/Support/Google.Apis.Auth/OAuth2/Web/AuthorizationCodeWebApp.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/Web/AuthorizationCodeWebApp.cs
@@ -15,6 +15,8 @@ limitations under the License.
 */
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -57,27 +59,14 @@ namespace Google.Apis.Auth.OAuth2.Web
             public string RedirectUri { get; set; }
         }
 
-        private readonly IAuthorizationCodeFlow flow;
-        private readonly string redirectUri;
-        private readonly string state;
-
         /// <summary>Gets the authorization code flow.</summary>
-        public IAuthorizationCodeFlow Flow
-        {
-            get { return flow; }
-        }
+        public IAuthorizationCodeFlow Flow { get; private set; }
 
         /// <summary>Gets the OAuth2 callback redirect URI.</summary>
-        public string RedirectUri
-        {
-            get { return redirectUri; }
-        }
+        public string RedirectUri { get; private set; }
 
         /// <summary>Gets the state which is used to navigate back to the page that started the OAuth flow.</summary>
-        public string State
-        {
-            get { return state; }
-        }
+        public string State { get; private set; }
 
         /// <summary>
         /// Constructs a new authorization code installed application with the given flow and code receiver.
@@ -85,9 +74,9 @@ namespace Google.Apis.Auth.OAuth2.Web
         public AuthorizationCodeWebApp(IAuthorizationCodeFlow flow, string redirectUri, string state)
         {
             // TODO(peleyal): Provide a way to disable to random number in the end of the state parameter.
-            this.flow = flow;
-            this.redirectUri = redirectUri;
-            this.state = state;
+            Flow = flow;
+            RedirectUri = redirectUri;
+            State = state;
         }
 
         /// <summary>Asynchronously authorizes the web application to access user's protected data.</summary>
@@ -105,11 +94,11 @@ namespace Google.Apis.Auth.OAuth2.Web
             if (ShouldRequestAuthorizationCode(token))
             {
                 // Create an authorization code request.
-                AuthorizationCodeRequestUrl codeRequest = Flow.CreateAuthorizationCodeRequest(redirectUri);
+                AuthorizationCodeRequestUrl codeRequest = Flow.CreateAuthorizationCodeRequest(RedirectUri);
 
                 // Add a random number to the end of the state so we can indicate the original request was made by this
                 // call.
-                var oauthState = state;
+                var oauthState = State;
                 if (Flow.DataStore != null)
                 {
                     var rndString = new string('9', StateRandomLength);
@@ -122,7 +111,7 @@ namespace Google.Apis.Auth.OAuth2.Web
                 return new AuthResult { RedirectUri = codeRequest.Build().AbsoluteUri };
             }
 
-            return new AuthResult { Credential = new UserCredential(flow, userId, token) };
+            return new AuthResult { Credential = new UserCredential(Flow, userId, token) };
         }
 
         /// <summary>
@@ -132,17 +121,27 @@ namespace Google.Apis.Auth.OAuth2.Web
         public bool ShouldRequestAuthorizationCode(TokenResponse token)
         {
             // TODO: This code should be shared between this class and AuthorizationCodeInstalledApp.
-            // If the flow includes a parameter that requires a new token, if the stored token is null or it doesn't
-            // have a refresh token and the access token is expired we need to retrieve a new authorization code.
 
-            if (token?.AccessToken == null) return true;
+            // If the token or access-token is null, need to retrieve a new authorization code.
+            if (token?.AccessToken == null)
+            {
+                return true;
+            }
 
-            if (token.IsExpired(Flow.Clock) && token.RefreshToken == null) return true;
+            // Is the token is expired, and we don't have a refresh token, need to retrieve a new auth code.
+            if (token.IsExpired(Flow.Clock) && token.RefreshToken == null)
+            {
+                return true;
+            }
 
             // If the current token.Scope does not include the requested scopes, then
             // an authorization code is required.
-            var scope = string.Join(" ", Flow.Scopes);
-            if (scope.Equals(token.Scope)) return false;
+            var tokenScopes = new HashSet<string>(token.Scope.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries));
+            if (Flow.Scopes.All(x => tokenScopes.Contains(x)))
+            {
+                // All requested scopes have already been authorized.
+                return false;
+            }
 
             // GoogleAuthorizationCodeFlow always returns true if IncludeGrantedScopes is true.
             return Flow.ShouldForceTokenRetrieval();

--- a/Src/Support/Google.Apis.Auth/OAuth2/Web/AuthorizationCodeWebApp.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/Web/AuthorizationCodeWebApp.cs
@@ -14,15 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+using Google.Apis.Auth.OAuth2.Flows;
+using Google.Apis.Auth.OAuth2.Requests;
+using Google.Apis.Auth.OAuth2.Responses;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-
-using Google.Apis.Auth.OAuth2.Flows;
-using Google.Apis.Auth.OAuth2.Requests;
-using Google.Apis.Auth.OAuth2.Responses;
 
 namespace Google.Apis.Auth.OAuth2.Web
 {


### PR DESCRIPTION
Move IncludeGrantedScopes to IAuthorizationCodeFlow. If true, add the previously granted scopes to the new token.Scope.